### PR TITLE
Rewrite the KbdRptParser (mapping) to use ref-counting.

### DIFF
--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -88,6 +88,12 @@ void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
   } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
     tk_press(tk_Fctn);
     tk_press(tk_A);
+  } else if (key == U_BACKQUOTE && !ISSHIFT(mod)) {
+    tk_press(tk_Fctn);
+    tk_press(tk_C);
+  } else if (key == U_BACKQUOTE && ISSHIFT(mod)) {
+    tk_press(tk_Fctn);
+    tk_press(tk_W);
   }
 }
 
@@ -112,6 +118,12 @@ void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
     tk_release(tk_Fctn);
   } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
     tk_release(tk_A);
+    tk_release(tk_Fctn);
+  } else if (key == U_BACKQUOTE && !ISSHIFT(mod)) {
+    tk_release(tk_C);
+    tk_release(tk_Fctn);
+  } else if (key == U_BACKQUOTE && ISSHIFT(mod)) {
+    tk_release(tk_W);
     tk_release(tk_Fctn);
   }
   

--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -62,14 +62,58 @@ void TiKbdRptParser::OnControlKeysChanged(uint8_t before, uint8_t after)
   updateModifier(U_LEFTCTRL | U_RIGHTCTRL, before, after, tk_Ctrl);
 }
 
+#define ISSHIFT(X) ((U_LEFTSHIFT | U_RIGHTSHIFT) & X)
+#define ISALT(X) ((U_LEFTALT | U_RIGHTALT) & X)
+#define ISCTRL(X) ((U_LEFTCTRL | U_RIGHTCTRL) & X)
+
 void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
 {
-  handleSimple(key, 1);
+  if (handleSimple(key, 1)) return;
+
+  if (key == U_HYPHEN && mod == 0) {
+    tk_press(tk_Shift);
+    tk_press(tk_Slash);
+  } else if (key == U_HYPHEN && ISSHIFT(mod)) {
+    tk_release(tk_Shift);
+    tk_press(tk_Fctn);
+    tk_press(tk_U);
+  } else if (key == U_SLASH && !ISSHIFT(mod)) {
+    tk_press(tk_Slash);
+  } else if (key == U_SLASH && ISSHIFT(mod)) {
+    tk_press(tk_Fctn);
+    tk_press(tk_I);
+  } else if (key == U_BACKSLASH && !ISSHIFT(mod)) {
+    tk_press(tk_Fctn);
+    tk_press(tk_Z);
+  } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
+    tk_press(tk_Fctn);
+    tk_press(tk_A);
+  }
 }
 
 void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
 {
   if (handleSimple(key, 0)) return;
+
+  if (key == U_HYPHEN && mod == 0) {
+    tk_release(tk_Slash);
+    tk_release(tk_Shift);
+  } else if (key == U_HYPHEN && ISSHIFT(mod)) {
+    tk_release(tk_U);
+    tk_release(tk_Fctn);
+    tk_press(tk_Shift);
+  } else if (key == U_SLASH && !ISSHIFT(mod)) {
+    tk_release(tk_Slash);
+  } else if (key == U_SLASH && ISSHIFT(mod)) {
+    tk_release(tk_I);
+    tk_release(tk_Fctn);
+  } else if (key == U_BACKSLASH && !ISSHIFT(mod)) {
+    tk_release(tk_Z);
+    tk_release(tk_Fctn);
+  } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
+    tk_release(tk_A);
+    tk_release(tk_Fctn);
+  }
   
   switch(key) {
     case U_CAPSLOCK:
@@ -78,54 +122,54 @@ void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
   }
 }
 
-#define SCASE(X, Y) case X: *Y = state; return true;
+#define SCASE(X, Y) case X: *Y = state; return true
 
 // Handle the keys that are a one to one mapping, with no modifier issues.
 boolean TiKbdRptParser::handleSimple(uint8_t key, int state)
 {
   switch(key) {
-    SCASE(U_NUM1,tk_1)
-    SCASE(U_NUM2,tk_2)
-    SCASE(U_NUM3,tk_3)
-    SCASE(U_NUM4,tk_4)
-    SCASE(U_NUM5,tk_5)
-    SCASE(U_NUM6,tk_6)
-    SCASE(U_NUM7,tk_7)
-    SCASE(U_NUM8,tk_8)
-    SCASE(U_NUM9,tk_9)
-    SCASE(U_NUM0,tk_0)
-    SCASE(U_A,tk_A)
-    SCASE(U_B,tk_B)
-    SCASE(U_C,tk_C)
-    SCASE(U_D,tk_D)
-    SCASE(U_E,tk_E)
-    SCASE(U_F,tk_F)
-    SCASE(U_G,tk_G)
-    SCASE(U_H,tk_H)
-    SCASE(U_I,tk_I)
-    SCASE(U_J,tk_J)
-    SCASE(U_K,tk_K)
-    SCASE(U_L,tk_L)
-    SCASE(U_M,tk_M)
-    SCASE(U_N,tk_N)
-    SCASE(U_O,tk_O)
-    SCASE(U_P,tk_P)
-    SCASE(U_Q,tk_Q)
-    SCASE(U_R,tk_R)
-    SCASE(U_S,tk_S)
-    SCASE(U_T,tk_T)
-    SCASE(U_U,tk_U)
-    SCASE(U_V,tk_V)
-    SCASE(U_W,tk_W)
-    SCASE(U_X,tk_X)
-    SCASE(U_Y,tk_Y)
-    SCASE(U_Z,tk_Z)
-    SCASE(U_COMMA,tk_Comma)
-    SCASE(U_PERIOD,tk_Period)
-    SCASE(U_EQUAL,tk_Equal)
-    SCASE(U_SEMICOLON,tk_Semicolon)
-    SCASE(U_SPACE,tk_Space)
-    SCASE(U_ENTER,tk_Enter)
+    SCASE(U_NUM1,tk_1);
+    SCASE(U_NUM2,tk_2);
+    SCASE(U_NUM3,tk_3);
+    SCASE(U_NUM4,tk_4);
+    SCASE(U_NUM5,tk_5);
+    SCASE(U_NUM6,tk_6);
+    SCASE(U_NUM7,tk_7);
+    SCASE(U_NUM8,tk_8);
+    SCASE(U_NUM9,tk_9);
+    SCASE(U_NUM0,tk_0);
+    SCASE(U_A,tk_A);
+    SCASE(U_B,tk_B);
+    SCASE(U_C,tk_C);
+    SCASE(U_D,tk_D);
+    SCASE(U_E,tk_E);
+    SCASE(U_F,tk_F);
+    SCASE(U_G,tk_G);
+    SCASE(U_H,tk_H);
+    SCASE(U_I,tk_I);
+    SCASE(U_J,tk_J);
+    SCASE(U_K,tk_K);
+    SCASE(U_L,tk_L);
+    SCASE(U_M,tk_M);
+    SCASE(U_N,tk_N);
+    SCASE(U_O,tk_O);
+    SCASE(U_P,tk_P);
+    SCASE(U_Q,tk_Q);
+    SCASE(U_R,tk_R);
+    SCASE(U_S,tk_S);
+    SCASE(U_T,tk_T);
+    SCASE(U_U,tk_U);
+    SCASE(U_V,tk_V);
+    SCASE(U_W,tk_W);
+    SCASE(U_X,tk_X);
+    SCASE(U_Y,tk_Y);
+    SCASE(U_Z,tk_Z);
+    SCASE(U_COMMA,tk_Comma);
+    SCASE(U_PERIOD,tk_Period);
+    SCASE(U_EQUAL,tk_Equal);
+    SCASE(U_SEMICOLON,tk_Semicolon);
+    SCASE(U_SPACE,tk_Space);
+    SCASE(U_ENTER,tk_Enter);
   }
   return false;
 }

--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -124,6 +124,8 @@ boolean TiKbdRptParser::handleSimple(uint8_t key, int state)
     SCASE(U_PERIOD,tk_Period)
     SCASE(U_EQUAL,tk_Equal)
     SCASE(U_SEMICOLON,tk_Semicolon)
+    SCASE(U_SPACE,tk_Space)
+    SCASE(U_ENTER,tk_Enter)
   }
   return false;
 }

--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -21,6 +21,16 @@ class TiKbdRptParser : public KeyboardReportParser
     boolean handleSimple(uint8_t key, int state);
     boolean handleFunction(uint8_t key, int state);
     boolean handleArrows(uint8_t key, int state);
+    boolean backquote = false;
+    boolean backslash = false;
+    boolean doublequote = false;
+    boolean hyphen = false;
+    boolean pipe = false;
+    boolean question = false;
+    boolean quote = false;
+    boolean slash = false;
+    boolean tilde = false;
+    boolean underscore = false;
 
   public:
     TiKbdRptParser();
@@ -77,33 +87,43 @@ void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
   if (key == U_HYPHEN && mod == 0) {
     tk_press(tk_Shift);
     tk_press(tk_Slash);
+    hyphen = true;
   } else if (key == U_HYPHEN && ISSHIFT(mod)) {
     tk_release(tk_Shift);
     tk_press(tk_Fctn);
     tk_press(tk_U);
-  } else if (key == U_SLASH && !ISSHIFT(mod)) {
+    underscore = true;
+  } else if (key == U_SLASH && mod == 0) {
     tk_press(tk_Slash);
+    slash = true;
   } else if (key == U_SLASH && ISSHIFT(mod)) {
     tk_press(tk_Fctn);
     tk_press(tk_I);
-  } else if (key == U_BACKSLASH && !ISSHIFT(mod)) {
+    question = true;
+  } else if (key == U_BACKSLASH && mod == 0) {
     tk_press(tk_Fctn);
     tk_press(tk_Z);
+    backslash = true;
   } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
     tk_press(tk_Fctn);
     tk_press(tk_A);
-  } else if (key == U_BACKQUOTE && !ISSHIFT(mod)) {
+    pipe = true;
+  } else if (key == U_BACKQUOTE && mod == 0) {
     tk_press(tk_Fctn);
     tk_press(tk_C);
+    backquote = true;
   } else if (key == U_BACKQUOTE && ISSHIFT(mod)) {
     tk_press(tk_Fctn);
     tk_press(tk_W);
+    tilde = true;
   } else if (key == U_QUOTE && mod == 0) {
     tk_press(tk_Fctn);
     tk_press(tk_O);
+    quote = true;
   } else if (key == U_QUOTE && ISSHIFT(mod)) {
     tk_press(tk_Fctn);
     tk_press(tk_P);
+    doublequote = true;
   }
 }
 
@@ -116,45 +136,64 @@ void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
   // This section below creates bugs! If the modifier is released before the
   // primary key, then we don't releae the key in the TI keyboard.
 
-  if (key == U_HYPHEN && mod == 0) {
-    tk_release(tk_Slash);
-    tk_release(tk_Shift);
-  } else if (key == U_HYPHEN && ISSHIFT(mod)) {
-    tk_release(tk_U);
-    tk_release(tk_Fctn);
-    tk_press(tk_Shift);
-  } else if (key == U_SLASH && !ISSHIFT(mod)) {
-    tk_release(tk_Slash);
-  } else if (key == U_SLASH && ISSHIFT(mod)) {
-    tk_release(tk_I);
-    tk_release(tk_Fctn);
-  } else if (key == U_BACKSLASH && !ISSHIFT(mod)) {
-    tk_release(tk_Z);
-    tk_release(tk_Fctn);
-  } else if (key == U_BACKSLASH && ISSHIFT(mod)) {
-    tk_release(tk_A);
-    tk_release(tk_Fctn);
-  } else if (key == U_BACKQUOTE && !ISSHIFT(mod)) {
-    tk_release(tk_C);
-    tk_release(tk_Fctn);
-  } else if (key == U_BACKQUOTE && ISSHIFT(mod)) {
-    tk_release(tk_W);
-    tk_release(tk_Fctn);
-  } else if (key == U_QUOTE && mod == 0) {
-    tk_release(tk_O);
-    tk_release(tk_Fctn);
-  } else if (key == U_QUOTE && ISSHIFT(mod)) {
-    tk_release(tk_P);
-    tk_release(tk_Fctn);
+
+  if (key == U_HYPHEN) {
+    if (underscore) {
+      tk_release(tk_U);
+      tk_release(tk_Fctn);
+      tk_press(tk_Shift);
+      underscore = false;
+    } else {
+      tk_release(tk_Slash);
+      tk_release(tk_Shift);
+      hyphen = false;
+    }
+  } else if (key == U_SLASH) {
+    if (question) {
+      tk_release(tk_Fctn);
+      tk_release(tk_I);
+      question = false;
+    } else {
+      tk_release(tk_Slash);
+      slash = false;
+    }
+  } else if (key == U_BACKSLASH) {
+    if (pipe) {
+      tk_release(tk_A);
+      tk_release(tk_Fctn);
+      pipe = false;
+    } else {
+      tk_release(tk_Z);
+      tk_release(tk_Fctn);
+      backslash = false;
+    }
+  } else if (key == U_BACKQUOTE) {
+    if (tilde) {
+      tk_release(tk_W);
+      tk_release(tk_Fctn);
+      tilde = false;
+    } else {
+      tk_release(tk_C);
+      tk_release(tk_Fctn);
+      backquote = false;
+    }
+  } else if (key == U_QUOTE) {
+    if (doublequote) {
+      tk_release(tk_P);
+      tk_release(tk_Fctn);
+      doublequote = false;
+    } else {
+      tk_release(tk_O);
+      tk_release(tk_Fctn);
+      quote = false;
+    }
   }
-  
-  switch(key) {
-    case U_CAPSLOCK:
+   
+  else if (key == U_CAPSLOCK) {
       *tk_Alpha = kbdLockingKeys.kbdLeds.bmCapsLock;
-      break;
   }
 
-  if (key == U_DELETE && ISCTRL(mod) && ISALT(mod)) {
+  else if (key == U_DELETE && ISCTRL(mod) && ISALT(mod)) {
     CPU_RESTART;
   }
 }

--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -19,6 +19,7 @@ class TiKbdRptParser : public KeyboardReportParser
   private:
     void updateModifier(uint8_t mask, uint8_t before, uint8_t after, int* tk);
     boolean handleSimple(uint8_t key, int state);
+    boolean handleFunction(uint8_t key, int state);
 
   public:
     TiKbdRptParser();
@@ -69,6 +70,7 @@ void TiKbdRptParser::OnControlKeysChanged(uint8_t before, uint8_t after)
 void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
 {
   if (handleSimple(key, 1)) return;
+  if (mod == 0 && handleFunction(key, 1)) return;
 
   if (key == U_HYPHEN && mod == 0) {
     tk_press(tk_Shift);
@@ -100,6 +102,7 @@ void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
 void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
 {
   if (handleSimple(key, 0)) return;
+  if (mod == 0 && handleFunction(key, 0)) return;
 
   if (key == U_HYPHEN && mod == 0) {
     tk_release(tk_Slash);
@@ -186,6 +189,28 @@ boolean TiKbdRptParser::handleSimple(uint8_t key, int state)
   return false;
 }
 
+#define FCASE(X, Y) case X: if(state) { tk_press(tk_Fctn); tk_press(Y); } else { tk_release(Y); tk_release(tk_Fctn); } return true
+#define CCASE(X, Y) case X: if(state) { tk_press(tk_Ctrl); tk_press(Y); } else { tk_release(Y); tk_release(tk_Ctrl); } return true
+
+boolean TiKbdRptParser::handleFunction(uint8_t key, int state)
+{
+  switch(key) {
+    FCASE(U_BACKSPACE,tk_S);
+    FCASE(U_F1,tk_1);
+    FCASE(U_F2,tk_2);
+    FCASE(U_F3,tk_3);
+    FCASE(U_F4,tk_4);
+    FCASE(U_F5,tk_5);
+    FCASE(U_F6,tk_6);
+    FCASE(U_F7,tk_7);
+    FCASE(U_F8,tk_8);
+    FCASE(U_F9,tk_9);
+    FCASE(U_F10,tk_0);
+    CCASE(U_F11,tk_1);
+    CCASE(U_F12,tk_2);
+  }
+  return false;
+}
 
 #endif
 

--- a/TI99USBKeys/TiKbdRptParser.h
+++ b/TI99USBKeys/TiKbdRptParser.h
@@ -21,6 +21,7 @@ class TiKbdRptParser : public KeyboardReportParser
     boolean handleSimple(uint8_t key, int state);
     boolean handleFunction(uint8_t key, int state);
     boolean handleArrows(uint8_t key, int state);
+    boolean handleNumpad(uint8_t key, int state);
     boolean backquote = false;
     boolean backslash = false;
     boolean doublequote = false;
@@ -83,6 +84,7 @@ void TiKbdRptParser::OnKeyDown(uint8_t mod, uint8_t key)
   if (handleSimple(key, 1)) return;
   if (mod == 0 && handleFunction(key, 1)) return;
   if (mod == 0 && handleArrows(key, 1)) return;
+  if (mod == 0 && handleNumpad(key, 1)) return;
 
   if (key == U_HYPHEN && mod == 0) {
     tk_press(tk_Shift);
@@ -132,6 +134,7 @@ void TiKbdRptParser::OnKeyUp(uint8_t mod, uint8_t key)
   if (handleSimple(key, 0)) return;
   if (mod == 0 && handleFunction(key, 0)) return;
   if (mod == 0 && handleArrows(key, 0)) return;
+  if (mod == 0 && handleNumpad(key, 0)) return;
 
   // This section below creates bugs! If the modifier is released before the
   // primary key, then we don't releae the key in the TI keyboard.
@@ -308,6 +311,39 @@ boolean TiKbdRptParser::handleArrows(uint8_t key, int state)
   return false;
 }
 
+boolean TiKbdRptParser::handleNumpad(uint8_t key, int state)
+{
+  if (!kbdLockingKeys.kbdLeds.bmNumLock) {
+    switch(key) {
+      FCASE(U_NUMPAD_PERIOD,tk_1);
+      CCASE(U_NUMPAD_1,tk_V);
+      FCASE(U_NUMPAD_2,tk_X);
+      FCASE(U_NUMPAD_3,tk_4);
+      FCASE(U_NUMPAD_4,tk_S);
+      BCASE(U_NUMPAD_5,tk_5);
+      FCASE(U_NUMPAD_6,tk_D);
+      CCASE(U_NUMPAD_7,tk_U);
+      FCASE(U_NUMPAD_8,tk_E);
+      FCASE(U_NUMPAD_9,tk_6);
+      FCASE(U_NUMPAD_0,tk_2);
+    }
+  } else {
+    switch(key) {
+      BCASE(U_NUMPAD_PERIOD,tk_Period);
+      BCASE(U_NUMPAD_1,tk_1);
+      BCASE(U_NUMPAD_2,tk_2);
+      BCASE(U_NUMPAD_3,tk_3);
+      BCASE(U_NUMPAD_4,tk_4);
+      BCASE(U_NUMPAD_5,tk_5);
+      BCASE(U_NUMPAD_6,tk_6);
+      BCASE(U_NUMPAD_7,tk_7);
+      BCASE(U_NUMPAD_8,tk_8);
+      BCASE(U_NUMPAD_9,tk_9);
+      BCASE(U_NUMPAD_0,tk_0);
+    }
+  }
+  return false;
+}
 
 #endif
 

--- a/TI99USBKeys/TiVirtualState.h
+++ b/TI99USBKeys/TiVirtualState.h
@@ -107,5 +107,15 @@ boolean isHandsFree()
     && isRowHandsFree(c5rows);
 }
 
+void tk_release(int * key)
+{
+  *key = (*key - 1);
+}
+
+void tk_press(int * key)
+{
+  *key = (*key + 1);
+}
+
 #endif
 

--- a/TI99USBKeys/USBCodes.h
+++ b/TI99USBKeys/USBCodes.h
@@ -46,9 +46,6 @@
 #define U_TAB 0x2B
 #define U_ESC 0x29
 
-#define U_NUMSLASH 0x54
-#define U_NUMENTER 0x58
-
 #define U_CAPSLOCK 0x39
 
 #define U_LEFTSHIFT 32
@@ -81,9 +78,11 @@
 #define U_NUMPAD_0 0x62
 #define U_NUMPAD_PERIOD 0x63
 #define U_NUMPAD_SLASH 0x31
+#define U_NUMSLASH 0x54
 #define U_NUMPAD_STAR 0x55
 #define U_NUMPAD_HYPHEN 0x56
 #define U_NUMPAD_PLUS 0x57
+#define U_NUMPAD_ENTER 0x58
 
 #define U_Q 0x14
 #define U_W 0x1A

--- a/TI99USBKeys/USBCodes.h
+++ b/TI99USBKeys/USBCodes.h
@@ -1,0 +1,118 @@
+#ifndef _USB_CODES_H
+#define _USB_CODES_H
+
+
+#define U_BACKQUOTE 0x35
+#define U_OPENSQUARE 0x2F
+#define U_CLOSESQUARE 0x30
+#define U_BACKSLASH 0x31
+#define U_SLASH 0x38
+#define U_HYPHEN 0x2D
+#define U_QUOTE 0x34
+#define U_BACKQUOTE 0x35
+#define U_EQUAL 0x2E
+#define U_SEMICOLON 0x33
+#define U_ENTER 0x28
+#define U_COMMA 0x36
+#define U_PERIOD 0x37
+#define U_SPACE 0x2C
+#define U_BACKSPACE 0x2A
+#define U_LEFTARROW 0x50
+#define U_RIGHTARROW 0x4F
+#define U_UPARROW 0x52
+#define U_DOWNARROW 0x51
+#define U_QUOTE 0x34
+#define U_HOME 0x4A
+#define U_END 0x4D
+
+#define U_F1 0x3A
+#define U_F2 0x3B
+#define U_F3 0x3C
+#define U_F4 0x3D
+#define U_F5 0x3E
+#define U_F6 0x3F
+#define U_F7 0x40
+#define U_F8 0x41
+#define U_F9 0x42
+#define U_F10 0x43
+#define U_F11 0x44
+#define U_F12 0x45
+
+#define U_DELETE 0x4C
+#define U_INSERT 0x49
+#define U_BREAK 0x48
+#define U_PGDN 0x4E
+#define U_PGUP 0x4B
+#define U_TAB 0x2B
+#define U_ESC 0x29
+
+#define U_NUMSLASH 0x54
+#define U_NUMENTER 0x58
+
+#define U_CAPSLOCK 0x39
+
+#define U_LEFTSHIFT 32
+#define U_RIGHTSHIFT 2
+#define U_LEFTALT 64
+#define U_RIGHTALT 4
+#define U_LEFTCTRL 16
+#define U_RIGHTCTRL 1
+
+#define U_NUM1 0x1E
+#define U_NUM2 0x1F
+#define U_NUM3 0x20
+#define U_NUM4 0x21
+#define U_NUM5 0x22
+#define U_NUM6 0x23
+#define U_NUM7 0x24
+#define U_NUM8 0x25
+#define U_NUM9 0x26
+#define U_NUM0 0x27
+
+#define U_NUMPAD_1 0x59
+#define U_NUMPAD_2 0x5A
+#define U_NUMPAD_3 0x5B
+#define U_NUMPAD_4 0x5C
+#define U_NUMPAD_5 0x5D
+#define U_NUMPAD_6 0x5E
+#define U_NUMPAD_7 0x5F
+#define U_NUMPAD_8 0x60
+#define U_NUMPAD_9 0x61
+#define U_NUMPAD_0 0x62
+#define U_NUMPAD_PERIOD 0x63
+#define U_NUMPAD_SLASH 0x31
+#define U_NUMPAD_STAR 0x55
+#define U_NUMPAD_HYPHEN 0x56
+#define U_NUMPAD_PLUS 0x57
+
+#define U_Q 0x14
+#define U_W 0x1A
+#define U_E 0x08
+#define U_R 0x15
+#define U_T 0x17
+#define U_Y 0x1C
+#define U_U 0x18
+#define U_I 0x0C
+#define U_O 0x12
+#define U_P 0x13
+
+#define U_A 0x04
+#define U_S 0x16
+#define U_D 0x07
+#define U_F 0x09
+#define U_G 0x0A
+#define U_H 0x0B
+#define U_J 0x0D
+#define U_K 0x0E
+#define U_L 0x0F
+
+#define U_Z 0x1D
+#define U_X 0x1B
+#define U_C 0x06
+#define U_V 0x19
+#define U_B 0x05
+#define U_N 0x11
+#define U_M 0x10
+
+#endif
+


### PR DESCRIPTION
There were two major issues with the previous that required a rewrite to support.
1. The TI can read modifiers all by themselves. My mapping did not support that. 
2. Shift would get logically stuck on. 

I believe this mapping supports all of the TI keyboard input, with mappings for the 101 key keyboards extra keys, pretty close to what is supported in Classic99. 
